### PR TITLE
Conditionally populate tide predictions

### DIFF
--- a/pillarpointstewards/shifts/views.py
+++ b/pillarpointstewards/shifts/views.py
@@ -17,7 +17,7 @@ from .ics_utils import calendar
 from auth0_login.utils import active_user_required
 from homepage.models import Fragment
 from tides.views import tide_times_svg_context_for_shift, tide_times_svg_context
-from tides.models import Location
+from tides.models import Location, TidePrediction
 from teams.models import Team
 from typing import Union
 from ulid import ULID
@@ -574,6 +574,10 @@ def manage_shifts_calculator(request, program_slug):
     earliest_shift_time_buffer = data["earliest-shift-time-buffer"]
     shortest_shift_duration = data["shortest-shift-duration"]
     people_per_regular_shift = data["people-per-regular-shift"]
+
+    # Check if tide predictions need to be populated for the station
+    if TidePrediction.should_populate_tide_predictions(team.location.station_id):
+        TidePrediction.populate_for_station(team.location.station_id)
 
     with connection.cursor() as cursor:
         cursor.execute(

--- a/pillarpointstewards/tides/models.py
+++ b/pillarpointstewards/tides/models.py
@@ -1,9 +1,8 @@
 from astral import LocationInfo, sun
 from django.db import models
 from django.utils.dateparse import parse_datetime
-from datetime import timezone
+from datetime import timezone, datetime, timedelta
 from urllib.parse import urlencode
-import datetime
 import httpx
 import pytz
 
@@ -54,6 +53,14 @@ class TidePrediction(models.Model):
             ignore_conflicts=True,
             batch_size=1000,
         )
+
+    @classmethod
+    def should_populate_tide_predictions(cls, station_id):
+        latest_record = cls.objects.filter(station_id=station_id).order_by('-dt').first()
+        if latest_record:
+            six_months_ahead = datetime.now() + timedelta(days=180)
+            return latest_record.dt < six_months_ahead
+        return True
 
 
 class Location(models.Model):

--- a/pillarpointstewards/tides/tests.py
+++ b/pillarpointstewards/tides/tests.py
@@ -287,3 +287,32 @@ def test_location_populate_sunrise_sunsets():
     assert location.sunrise_sunsets.count() == 0
     location.populate_sunrise_sunsets()
     assert location.sunrise_sunsets.count() == 365
+
+@pytest.mark.django_db
+def test_should_populate_tide_predictions():
+    # Create a location and associated tide predictions
+    location = Location.objects.create(
+        name="Test Location",
+        station_id=9414131,
+        latitude=37.49542392,
+        longitude=-122.49865193,
+        time_zone="America/Los_Angeles",
+    )
+    # Create tide predictions for the past 6 months
+    past_date = datetime.datetime.now() - datetime.timedelta(days=180)
+    TidePrediction.objects.create(
+        station_id=location.station_id,
+        dt=past_date,
+        mllw_feet=5.0,
+    )
+    # Verify that should_populate_tide_predictions returns True
+    assert TidePrediction.should_populate_tide_predictions(location.station_id) is True
+    # Create a tide prediction for less than 6 months away
+    future_date = datetime.datetime.now() + datetime.timedelta(days=179)
+    TidePrediction.objects.create(
+        station_id=location.station_id,
+        dt=future_date,
+        mllw_feet=5.0,
+    )
+    # Verify that should_populate_tide_predictions now returns False
+    assert TidePrediction.should_populate_tide_predictions(location.station_id) is False


### PR DESCRIPTION
Implements conditional tide prediction population for a specific station and adds corresponding tests.

- **Adds a method** `should_populate_tide_predictions` in `TidePrediction` model to check if the furthest away record is more than 6 months away, returning `True` if conditions are met or `False` otherwise.
- **Updates** `manage_shifts_calculator` view to conditionally populate tide predictions for station 9414131 if the `should_populate_tide_predictions` method returns `True`.
- **Introduces tests** in `tides/tests.py` to verify the conditional population logic, ensuring that tide predictions are populated only when the furthest away record is more than 6 months away.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/natbat/pillarpointstewards?shareId=1d2e05ba-f36a-416b-b9fa-815ed64e5817).